### PR TITLE
Avoid negative latency

### DIFF
--- a/packet_writer.go
+++ b/packet_writer.go
@@ -43,6 +43,7 @@ func (p *Pinger) Send(req *EchoRequest) error {
 	if err != nil {
 		return err
 	}
+	req.Sent = time.Now()
 	if req.Destination.To4() == nil {
 		_, err = p.v6Conn.WriteTo(b, &net.IPAddr{IP: req.Destination})
 		if err != nil {
@@ -54,6 +55,5 @@ func (p *Pinger) Send(req *EchoRequest) error {
 			return err
 		}
 	}
-	req.Sent = time.Now()
 	return nil
 }


### PR DESCRIPTION
With the existing implementation, the go routine calling `Pinger.Send` can get descheduled just after `WriteTo` completes, and the response can arrive before `req.Sent = time.Now()` executes. This results in negative latency being reported.

This PR solves the problem by recording the time sent just before the request is actually sent. Note that this can lead to inflated latency. Feel free to reject this PR if negative latency seems preferable.